### PR TITLE
Changes for Code Analysis

### DIFF
--- a/scripts/chroot_dispatch.sh
+++ b/scripts/chroot_dispatch.sh
@@ -85,7 +85,7 @@ rm -rf $tmpdir
 
 sudo pbuilder execute \
     --basetgz $basetgz \
-    --bindmounts "/var/cache/pbuilder/ccache $WORKSPACE $HOME/.ssh" \
+    --bindmounts "/var/cache/pbuilder/ccache $WORKSPACE $HOME" \
     --inputfile $WORKSPACE/jenkins_scripts/$SCRIPT \
     -- $WORKSPACE/pbuilder-env.sh $SCRIPT
 


### PR DESCRIPTION
Hi,

for code analysis we only needed to mount the $HOME directory in the script "chroot_dispatch" while executing pbuilder.

Best,
Johannes
