### PR TITLE
remove deprecated package

### DIFF
--- a/scripts/chroot_update.sh
+++ b/scripts/chroot_update.sh
@@ -4,7 +4,7 @@
 
 apt-get update
 apt-get install -y \
-    python-setuptools ccache wget curl curl-ssl sudo git-buildpackage dput python-yaml python-pip python-support \
+    python-setuptools ccache wget curl sudo git-buildpackage dput python-yaml python-pip python-support \
     git-core mercurial subversion python-all gccxml python-empy python-nose python-mock python-minimock lsb-release \
     python-numpy python-wxgtk2.8 python-argparse python-networkx graphviz python-sphinx doxygen python-epydoc cmake pkg-config openssh-client
 


### PR DESCRIPTION
You get this on precise

```
root@host07:~# sudo apt-get install curl-ssl
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'curl' instead of 'curl-ssl'
The following packages will be upgraded:
  curl
1 upgraded, 0 newly installed, 0 to remove and 109 not upgraded.
Need to get 138 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 http://mirrors.liquidweb.com/ubuntu/ precise-updates/main curl amd64 7.22.0-3ubuntu4.6 [138 kB]
Fetched 138 kB in 2s (64.2 kB/s)
(Reading database ... 150890 files and directories currently installed.)
Preparing to replace curl 7.22.0-3ubuntu4.3 (using .../curl_7.22.0-3ubuntu4.6_amd64.deb) ...
Unpacking replacement curl ...
Processing triggers for man-db ...
Setting up curl (7.22.0-3ubuntu4.6) ...
```

And on trusty it just fails.
