### PR TITLE
add ubuntu distro for jade for devel and doc jobs, clarify ubuntu distros for prereleases

### DIFF
--- a/scripts/generate_jenkins_devel
+++ b/scripts/generate_jenkins_devel
@@ -15,7 +15,8 @@ from rospkg import environment
 ubuntu_distro = {'fuerte': ['precise'],
                  'groovy': ['precise'],
                  'hydro': ['precise'],
-                 'indigo': ['trusty']}
+                 'indigo': ['trusty'],
+                 'jade': ['trusty']}
 arch = ['amd64']
 
 

--- a/scripts/generate_jenkins_doc
+++ b/scripts/generate_jenkins_doc
@@ -18,7 +18,8 @@ ubuntu_distro = {'electric': ['lucid'],
                  'fuerte': ['precise'],
                  'groovy': ['precise'],
                  'hydro': ['precise'],
-                 'indigo': ['trusty']}
+                 'indigo': ['trusty'],
+                 'jade': ['trusty']}
 arch = ['amd64']
 
 

--- a/scripts/generate_jenkins_prerelease
+++ b/scripts/generate_jenkins_prerelease
@@ -59,7 +59,11 @@ def main():
     additional_publishers = pkg_resources.resource_string('jenkins_tools', 'resources/templates/publisher_notification_on_success.xml')
 
     # create all jobs
-    ubuntu_param = 'trusty' if ros_distro == 'indigo' else 'precise'
+    ubuntu_distro = {'groovy': ['precise'],
+                     'hydro': ['precise'],
+                     'indigo': ['trusty']}
+
+    ubuntu_param = ubuntu_distro[ros_distro]
     jenkins_tools.run_jenkins_now(jenkins_instance, '$UBUNTU_PARAM', '$ARCH_PARAM', job_name, 'ros-buildfarm-prerelease@googlegroups.com $EMAIL_PARAM',
                                   'prerelease',  # script to run
                                   script_args,  # script arguments


### PR DESCRIPTION
@esteve @wjwwood @tfoote Please review.

This fix needs to be released in order to generate devel and doc jobs for Jade.
